### PR TITLE
Merge two Kafka services together to streamline Compose file

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,6 @@
 services:
+
+  ################## DEMO WEB CLIENT ##################
   demo-client:
     image: node:lts-slim
     working_dir: /usr/local/app
@@ -52,7 +54,7 @@ services:
 
   ############## KAFKA AND VISUALIZATION ##############
   kafka:
-    image: apache/kafka-native:3.9.0
+    image: apache/kafka:3.9.0
     ports:
       - 9092:9092
     environment:
@@ -72,12 +74,8 @@ services:
 
       # Required for a single node cluster
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-
-  kafka-topic-creator:
-    image: apache/kafka:3.9.0
-    command: /opt/kafka/bin/kafka-topics.sh --create --topic products --partitions 1 --replication-factor 1 --bootstrap-server kafka:9093
-    depends_on:
-      - kafka
+    post_start:
+      - command: /opt/kafka/bin/kafka-topics.sh --create --topic products --partitions 1 --replication-factor 1 --bootstrap-server kafka:9093
 
   kafka-ui:
     image: ghcr.io/kafbat/kafka-ui:01aa8ab36387c5f1d66d098e71488bfb0eb5f39c


### PR DESCRIPTION
Merging the two Kafka services together to streamline the Compose file and take advantage of the `post_start` hook that was already in use with the localstack service.