### PR TITLE
Allow kafka container to be started again without errors

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -75,7 +75,7 @@ services:
       # Required for a single node cluster
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     post_start:
-      - command: /opt/kafka/bin/kafka-topics.sh --create --topic products --partitions 1 --replication-factor 1 --bootstrap-server kafka:9093
+      - command: /opt/kafka/bin/kafka-topics.sh --create --if-not-exists --topic products --partitions 1 --replication-factor 1 --bootstrap-server kafka:9093
 
   kafka-ui:
     image: ghcr.io/kafbat/kafka-ui:01aa8ab36387c5f1d66d098e71488bfb0eb5f39c


### PR DESCRIPTION
This updates the Compose `post_start` hook to be idempotent and not fail on subsequent starts.

The LocalStack container was confirmed to not fail its `post_start` hook on repeat runs.

Resolves #15