### PR TITLE
Skip building of cpu-features and ssh2 as they aren't needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,14 @@
     "prettier": "^3.4.0",
     "testcontainers": "^10.15.0"
   },
+  "dependenciesMeta": {
+    "cpu-features": {
+      "built": false
+    },
+    "ssh2": {
+      "built": false
+    }
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3060,6 +3060,11 @@ __metadata:
     pg: "npm:^8.13.0"
     prettier: "npm:^3.4.0"
     testcontainers: "npm:^10.15.0"
+  dependenciesMeta:
+    cpu-features:
+      built: false
+    ssh2:
+      built: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This is to help reduce the amount of setup required in order to use the project, as a compile setup wouldn't be required (and cpu-features requires cmake)

Resolves #22