### PR TITLE
Remove "version: lab" from DBC config as no longer needed

### DIFF
--- a/.github/workflows/pipeline-docker-cloud.yaml
+++ b/.github/workflows/pipeline-docker-cloud.yaml
@@ -137,7 +137,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: "lab:latest"
           driver: cloud
           endpoint: ${{ env.DBC_BUILDER_NAME }}
 


### PR DESCRIPTION
With the 3.8.0 release of the `docker/setup-buildx-action`, the version is automatically configured when using the cloud driver. Since this provides a better experience (why are we using the lab version again?), let's remove it!