### PR TITLE
Fix yarn usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN npm uninstall npm -g
 # Setup a non-root user to run the app
 WORKDIR /usr/local/app
 RUN useradd -m appuser && chown -R appuser /usr/local/app
-COPY package.json yarn.lock ./
+COPY --chown=appuser:appuser package.json yarn.lock .yarnrc.yml ./
+COPY --chown=appuser:appuser .yarn ./.yarn
 RUN corepack enable
 USER appuser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ CMD ["yarn", "dev-container"]
 ###########################################################
 FROM base AS final
 ENV NODE_ENV=production
-RUN yarn install && yarn cache clean
+RUN yarn workspaces focus --production && yarn cache clean
 COPY ./src ./src
 
 EXPOSE 3000

--- a/demo/e2e.patch
+++ b/demo/e2e.patch
@@ -26,7 +26,7 @@ index 6ac5706..edb8f38 100644
  FROM base AS final
 -ENV NODE_ENV=production
 +ENV NODE_ENV production
- RUN yarn install && yarn cache clean
+ RUN yarn workspaces focus --production && yarn cache clean
  COPY ./src ./src
  
  EXPOSE 3000

--- a/demo/e2e.patch
+++ b/demo/e2e.patch
@@ -1,5 +1,5 @@
 diff --git a/Dockerfile b/Dockerfile
-index a455ded..4fb23ba 100644
+index 6ac5706..edb8f38 100644
 --- a/Dockerfile
 +++ b/Dockerfile
 @@ -5,7 +5,7 @@
@@ -11,7 +11,7 @@ index a455ded..4fb23ba 100644
  
  # Remove npm to resolve a currently known and fixable vulnerability 
  RUN npm uninstall npm -g
-@@ -27,7 +27,7 @@ USER appuser
+@@ -28,7 +28,7 @@ USER appuser
  # and automatically restart the app.
  ###########################################################
  FROM base AS dev
@@ -20,7 +20,7 @@ index a455ded..4fb23ba 100644
  RUN yarn install
  CMD ["yarn", "dev-container"]
  
-@@ -39,10 +39,10 @@ CMD ["yarn", "dev-container"]
+@@ -40,10 +40,10 @@ CMD ["yarn", "dev-container"]
  # installs only the production dependencies.
  ###########################################################
  FROM base AS final

--- a/demo/scout.patch
+++ b/demo/scout.patch
@@ -26,7 +26,7 @@ index 6ac5706..edb8f38 100644
  FROM base AS final
 -ENV NODE_ENV=production
 +ENV NODE_ENV production
- RUN yarn install && yarn cache clean
+ RUN yarn workspaces focus --production && yarn cache clean
  COPY ./src ./src
  
  EXPOSE 3000

--- a/demo/scout.patch
+++ b/demo/scout.patch
@@ -1,3 +1,40 @@
+diff --git a/Dockerfile b/Dockerfile
+index 6ac5706..edb8f38 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -5,7 +5,7 @@
+ # By using this stage, it provides a consistent base for both
+ # the dev and prod versions of the image.
+ ###########################################################
+-FROM node:22-slim AS base
++FROM node:18 AS base
+ 
+ # Remove npm to resolve a currently known and fixable vulnerability 
+ RUN npm uninstall npm -g
+@@ -28,7 +28,7 @@ USER appuser
+ # and automatically restart the app.
+ ###########################################################
+ FROM base AS dev
+-ENV NODE_ENV=development
++ENV NODE_ENV development
+ RUN yarn install
+ CMD ["yarn", "dev-container"]
+ 
+@@ -40,10 +40,10 @@ CMD ["yarn", "dev-container"]
+ # installs only the production dependencies.
+ ###########################################################
+ FROM base AS final
+-ENV NODE_ENV=production
++ENV NODE_ENV production
+ RUN yarn install && yarn cache clean
+ COPY ./src ./src
+ 
+ EXPOSE 3000
+ 
+-CMD [ "node", "src/index.js" ]
+\ No newline at end of file
++CMD node src/index.js
+\ No newline at end of file
 diff --git a/package.json b/package.json
 index 3008f7d..c6fc3bd 100644
 --- a/package.json


### PR DESCRIPTION
There were a few other changes with the yarn update that didn't get caught. 

If we don't use the node-modules nodeLinker (defined in `.yarnrc.yml`), then we have to change the startup command to `yarn start` because a straight `node src/index.js` won't find all of the dependencies needed to start the app (they are cached in other locations, etc.). Funny enough though, the `yarn cache clear` actually removes all of those dependencies too, as they are no longer stored in the project's `node_modules` directory.

This change basically reverts the usage of PnP to using the local `node_modules` directory. Can revisit that strategy at some point in the future.