### PR TITLE
Adjust patch validation workflow to skip individual jobs

### DIFF
--- a/.github/workflows/validate-demo-patches.yaml
+++ b/.github/workflows/validate-demo-patches.yaml
@@ -5,13 +5,12 @@ on:
     branches-ignore:
       - "demo-**"
   pull_request:
-    branches-ignore:
-      - "demo-**"
   workflow_dispatch:
 
 jobs:
   extract:
     name: "Define demo patch matrix"
+    if: "!startsWith(github.head_ref, 'demo-')"
     runs-on: ubuntu-latest
     outputs:
       patchFiles: ${{ steps.extract.outputs.patchFiles }}
@@ -27,6 +26,7 @@ jobs:
 
   validate:
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'demo-')"
     needs: extract
     strategy:
       matrix:


### PR DESCRIPTION
Reasoning is that GitHub Actions doesn't have a way to filter based on the source branch, only on the target.

Third attempt to actually resolve #35