### PR TITLE
Add --experimental-vm-modules to tests

### DIFF
--- a/.env.node
+++ b/.env.node
@@ -1,2 +1,2 @@
 DEBUG=testcontainers*
-NODE_OPTIONS=--dns-result-order=ipv4first
+NODE_OPTIONS=--dns-result-order=ipv4first --experimental-vm-modules


### PR DESCRIPTION
Flag is thrown by the latest version of the s3 client. This fixes it.